### PR TITLE
Add SSIM image diffing mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "pixelmatch",
     "ressemble"
   ],
-  "version": "1.3.3",
+  "version": "1.4.0",
   "scripts": {
     "build": "tsc && terser ./dist/index.js -c -m --module  -o ./dist/index.js"
   },

--- a/src/examples/test-folders.ts
+++ b/src/examples/test-folders.ts
@@ -94,10 +94,7 @@ for (let i = 0; i < irpBoth.length; i++) {
   const baselineImageUnpadded = loadAsImageData(join(baselineFolder, irp));
   const candidateImageUnpadded = loadAsImageData(join(candidateFolder, irp));
 
-  hrTimer.tick("padImageDataTo16");
-  const baselineImage = utils.padImageDataTo16(baselineImageUnpadded);
-  const candidateImage = utils.padImageDataTo16(candidateImageUnpadded);
-  hrTimer.tick("padImageDataTo16");
+  const [baselineImage, candidateImage] = utils.matchDimensions(baselineImageUnpadded, candidateImageUnpadded, 64);
 
   const mep = 3;
   const { width, height } = baselineImage;

--- a/src/examples/test-folders.ts
+++ b/src/examples/test-folders.ts
@@ -90,8 +90,13 @@ for (let i = 0; i < irpBoth.length; i++) {
   const isPNG = irp.endsWith(".png");
 
   const loadAsImageData = isPNG ? utils.loadPngAsImageData : utils.loadJpgAsImageData;
-  const baselineImage = loadAsImageData(join(baselineFolder, irp));
-  const candidateImage = loadAsImageData(join(candidateFolder, irp));
+  const baselineImageUnpadded = loadAsImageData(join(baselineFolder, irp));
+  const candidateImageUnpadded = loadAsImageData(join(candidateFolder, irp));
+
+  hrTimer.tick("padImageDataTo16");
+  const baselineImage = utils.padImageDataTo16(baselineImageUnpadded);
+  const candidateImage = utils.padImageDataTo16(candidateImageUnpadded);
+  hrTimer.tick("padImageDataTo16");
 
   const mep = 3;
   const { width, height } = baselineImage;
@@ -101,7 +106,7 @@ for (let i = 0; i < irpBoth.length; i++) {
     data: new Uint8ClampedArray(width * height * 4 * mep),
     colorSpace: "srgb",
   };
-  const options = { threshold: 0.03, enableMinimap: true };
+  const options = { threshold: 0.03, enableMinimap: true, mode: "ssim" };
   hrTimer.tick("diff images");
   const result = diffImageDatas(baselineImage, candidateImage, difxPng, options);
   hrTimer.tick("diff images");

--- a/src/examples/test-folders.ts
+++ b/src/examples/test-folders.ts
@@ -88,6 +88,7 @@ console.log(
 for (let i = 0; i < irpBoth.length; i++) {
   const irp = irpBoth[i];
   const isPNG = irp.endsWith(".png");
+  console.log(`🖼️  ${irp}`);
 
   const loadAsImageData = isPNG ? utils.loadPngAsImageData : utils.loadJpgAsImageData;
   const baselineImageUnpadded = loadAsImageData(join(baselineFolder, irp));

--- a/src/examples/utils.ts
+++ b/src/examples/utils.ts
@@ -3,6 +3,8 @@ import * as fastPng from "fast-png";
 import { decode } from "jpeg-js";
 import * as hrTimer from "./hrTimer";
 
+const paddingABGR = 0x0007f7f7f;
+
 export const loadJpgAsImageData = (path: string): ImageData => {
   hrTimer.tick("read files");
   const pb = fs.readFileSync(path);
@@ -59,36 +61,45 @@ export const loadPngAsImageData = (path: string): ImageData => {
   return {width, height, data} as ImageData;
 };
 
-export const padImageDataTo16 = (src: ImageData): ImageData => {
-  const width = Math.ceil(src.width / 16) * 16; 
-  const height = Math.ceil(src.height / 16) * 16; 
+const padImageDataToDimensions = (src: ImageData, width: number, height: number): ImageData => {
   if (src.width === width && src.height === height) {
     return src;
   }
+
   const data = new Uint8ClampedArray(width * height * 4);
   const data32 = new Uint32Array(data.buffer, 0, width * height);
   const dst = {width, height, data} as ImageData;
 
-  const paddingARGB = 0x0ff7f7f7f;
-
   // Vertical padding
-  data32.fill(paddingARGB, width * src.height, width * height);
+  data32.fill(paddingABGR, dst.width * src.height, dst.width * dst.height);
 
-  if (src.width === width) {
+  if (src.width === dst.width) {
+    data.set(src.data, 0);
     return dst;
   }
 
   // Horizontal padding
   const srcWidthX4 = src.width * 4;
-  for (let y = 0; y <src.height; y++) {
+  for (let y = 0; y < src.height; y++) {
     const srcIndex = y * srcWidthX4;
     const dstIndex32 = y * width;
     const dstIndex = dstIndex32 * 4;
     // copy the src
-    data.set(src.data.subarray(srcIndex, srcWidthX4), dstIndex);
+//    data.set(src.data.subarray(srcIndex, srcWidthX4), dstIndex);
+    data.set(new Uint8ClampedArray(src.data.buffer, srcIndex, srcWidthX4), dstIndex);
     // pad
-    data32.fill(paddingARGB, dstIndex32 + srcWidthX4, dstIndex32 + width);
+    data32.fill(paddingABGR, dstIndex32 + srcWidthX4, dstIndex32 + width);
   }
 
   return dst;
-}
+};
+
+export const matchDimensions = (baseline: ImageData, candidate: ImageData, gridSize: number = 1): [ImageData, ImageData] => {
+  const width = Math.ceil(Math.max(baseline.width, candidate.width) / gridSize) * gridSize;
+  const height = Math.ceil(Math.max(baseline.height, candidate.height) / gridSize) * gridSize;
+
+  return [
+    padImageDataToDimensions(baseline, width, height),
+    padImageDataToDimensions(candidate, width, height)
+  ];
+};

--- a/src/examples/utils.ts
+++ b/src/examples/utils.ts
@@ -58,3 +58,37 @@ export const loadPngAsImageData = (path: string): ImageData => {
 
   return {width, height, data} as ImageData;
 };
+
+export const padImageDataTo16 = (src: ImageData): ImageData => {
+  const width = Math.ceil(src.width / 16) * 16; 
+  const height = Math.ceil(src.height / 16) * 16; 
+  if (src.width === width && src.height === height) {
+    return src;
+  }
+  const data = new Uint8ClampedArray(width * height * 4);
+  const data32 = new Uint32Array(data.buffer, 0, width * height);
+  const dst = {width, height, data} as ImageData;
+
+  const paddingARGB = 0x0ff7f7f7f;
+
+  // Vertical padding
+  data32.fill(paddingARGB, width * src.height, width * height);
+
+  if (src.width === width) {
+    return dst;
+  }
+
+  // Horizontal padding
+  const srcWidthX4 = src.width * 4;
+  for (let y = 0; y <src.height; y++) {
+    const srcIndex = y * srcWidthX4;
+    const dstIndex32 = y * width;
+    const dstIndex = dstIndex32 * 4;
+    // copy the src
+    data.set(src.data.subarray(srcIndex, srcWidthX4), dstIndex);
+    // pad
+    data32.fill(paddingARGB, dstIndex32 + srcWidthX4, dstIndex32 + width);
+  }
+
+  return dst;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ const COLOR32_MINIMAP = 0x0207f0000;
 const HASH_SPREAD = 0x0f0731337;
 
 export type Result = { diff: number; cumulatedDiff: number; hash: number };
-export type Options = { threshold?: number; cumulatedThreshold?: number; enableMinimap?: boolean };
+export type Options = { threshold: number; cumulatedThreshold?: number; enableMinimap?: boolean, mode?: string };
 
 /* PBD: Pixel Buffer Diff  */
 export const diffImageDatas = (
@@ -16,9 +16,14 @@ export const diffImageDatas = (
   diff: ImageData,
   options: Options
 ): Result => {
-  if (options.threshold === undefined) { options.threshold = 0.03; }
-  if (options.cumulatedThreshold === undefined) { options.cumulatedThreshold = .5; }
-  if (options.enableMinimap === undefined) { options.enableMinimap = false; }
+  const threshold = options.threshold ?? 0.03;
+  const cumulatedThreshold = options.cumulatedThreshold ?? 0.5;
+  const enableMinimap = options.enableMinimap ?? false;
+  const mode = options.mode ?? "basic";
+  // if (options.threshold === undefined) { options.threshold = 0.03; }
+  // if (options.cumulatedThreshold === undefined) { options.cumulatedThreshold = .5; }
+  // if (options.enableMinimap === undefined) { options.enableMinimap = false; }
+  // if (options.mode === undefined) { options.mode = "basic"; }
 
   const { width, height } = baseline;
   const area = width * height;
@@ -32,11 +37,17 @@ export const diffImageDatas = (
   if (width !== candidate.width || height !== candidate.height || area * 4 !== b8l || b8l !== c8l) {
     throw new Error("Different baseline and candidate ImageData dimensions");
   }
+
+  if (mode === "ssim" && (width | height) & 15) {
+    throw new Error("Invalid ImageData dimensions for ssim mode");
+  }
+
   const wRatio = diff.width / width;
   const lRatio = d8l / b8l;
   if (diff.height !== height || wRatio !== lRatio || (wRatio !== 1 && wRatio !== 3)) {
     throw new Error("Invalid diff ImageData dimensions");
   }
+
 
   const diffType = d8l === b8l ? DiffOnly : SideBySide;
   const bBuffer = baseline8.buffer;
@@ -47,7 +58,7 @@ export const diffImageDatas = (
   const diff32 = new Uint32Array(dBuffer, 0, d8l >> 2);
   // maximum acceptable square distance between two colors;
   // 35215 is the maximum possible value for the YIQ difference metric
-  const deltaThreshold = options.threshold * options.threshold * 35215;
+  const deltaThreshold = threshold * threshold * 35215;
 
   let b8i = 0;
   let b32i = 0;
@@ -76,95 +87,168 @@ export const diffImageDatas = (
   const color32Added = isDarkTheme ? COLOR32_ADDED : COLOR32_REMOVED;
   const color32Removed = isDarkTheme ? COLOR32_REMOVED : COLOR32_ADDED;
 
-  // Diff every pixel
-  b8i = 0;
-  const miniHeight = Math.ceil(height / MINIMAP_SCALE);
-  const miniWidth = Math.ceil(width / MINIMAP_SCALE);
-  const miniMap = new Uint8ClampedArray(miniWidth * miniHeight);
-  const d32iPadding = diffType === SideBySide ? width : 0;
-  const d32iWidth = d32iPadding * 2 + width;
-  const maxDimension = Math.max(width, height);
-  const maxMiniDimension = Math.max(miniWidth, miniHeight);
-  const axisMiniIndex = new Uint32Array(maxDimension);
+  if (mode === "ssim") {
+    // SSIM diff by 16x16 patch
 
-  let miniIndex = 0;
-  for (let i = 0; i < maxMiniDimension; i++) {
-    axisMiniIndex.fill(i, miniIndex, Math.min(miniIndex + MINIMAP_SCALE, maxDimension));
-    miniIndex += MINIMAP_SCALE;
-  }
-
-  for (let y = 0; y < height; y++) {
-    const miniIndexY = axisMiniIndex[y] * miniWidth;
-    // For side-by-side diff, copy the baseline and candidate on the sides
-    if (d32iPadding > 0) {
-      diff32.set(new Uint32Array(bBuffer, b8i, width), d32i);
-      d32i += width;
-      diff32.set(new Uint32Array(cBuffer, b8i, width), d32i + width);
-    }
-
-    let hashIndex = (y ^ HASH_SPREAD) * HASH_SPREAD;
-    for (let x = 0; x < width; x++, d32i++, b32i++, b8i += 4, hashIndex++) {
-      // Quick check against the Uint32
-      if (baseline32[b32i] === candidate32[b32i]) {
-        continue;
+    // prepare patch offsets to walk within the patches
+    const patchOffsets32 = [];
+    for (let y = 0; y < 16; y++) {
+      for (let x = 0; x < 16; x++) {
+        patchOffsets32.push(x + y * width);
       }
+    }
+    const patchOffsets8 = patchOffsets32.map(v => v * 4);
 
-      // Get the r,g,b -> y,i,q => YIQ square delta
-      const dr = candidate8[b8i] - baseline8[b8i];
-      const dg = candidate8[b8i + 1] - baseline8[b8i + 1];
-      const db = candidate8[b8i + 2] - baseline8[b8i + 2];
+    // SSIM constants
+    const K1 = 0.01;
+    const K2 = 0.03;
+    const C1 = (K1 * 255) ** 2;
+    const C2 = (K2 * 255) ** 2;
+    // Walk each patch, track the lowest SSIM aka lowest similarity
+    let lowestSsim = 1;
+    for (let y = 0; y < height; y += 16) {
+      for (let x = 0; x < width; x += 16) {
+        const index32 = x + y * width;
 
-      const dy = dr * 0.29889531 + dg * 0.58662247 + db * 0.11448223;
-      const di = dr * 0.59597799 - dg * 0.27417610 - db * 0.32180189;
-      const dq = dr * 0.21147017 - dg * 0.52261711 + db * 0.31114694;
-
-      const delta = dy * dy * 0.5053 + di * di * 0.299 + dq * dq * 0.1957;
-      if (delta > deltaThreshold) {
-        const miniIndex = miniIndexY + axisMiniIndex[x];
-        miniMap[miniIndex]++;
-        diffCount++;
-        const dyAbs = Math.abs(dy);
-        cumulatedDiff += dyAbs;
-        diff32[d32i] =
-          (dy > 0 ? color32Added : color32Removed) +
-          (Math.min(192, dyAbs * 8) << 24);
-
-        if (hash === 0) {
-          hashStart = hashIndex;
+        let ssim = 1;
+        // Quick check using RGBA32 values
+        let breakAndComputeSsim = false;
+        for (let i = 0; i < 256 && !breakAndComputeSsim; i++) {
+          const indexPlusOffset32 = index32 + patchOffsets32[i];
+          breakAndComputeSsim = baseline32[indexPlusOffset32] !== candidate32[indexPlusOffset32];
         }
-        hash += hashIndex;
-      }
-    }
-    d32i += d32iPadding;
-  }
-  hash -= hashStart;
-  cumulatedDiff /= 256;
+        if (breakAndComputeSsim) {
+          // walk patch on 8bits valuse to compute the Y, and SSIM
+          // Single pass computation
+          const index8 = index32 * 4;
+          let sum1 = 0, sum2 = 0, sum1Sq = 0, sum2Sq = 0, sum12 = 0;
+          for (let i = 0; i < 256; i++) {
+            const indexPlusOffset8 = index8 + patchOffsets8[i];
+            const bY = baseline8[indexPlusOffset8] * 0.29889531 + baseline8[indexPlusOffset8 + 1] * 0.58662247 + baseline8[indexPlusOffset8 + 2] * 0.11448223;;
+            const cY = candidate8[indexPlusOffset8] * 0.29889531 + candidate8[indexPlusOffset8 + 1] * 0.58662247 + candidate8[indexPlusOffset8 + 2] * 0.11448223;;
 
-  // Apply minimap overlay
-  if (options.enableMinimap) {
-    for (let i = 0; i < miniWidth * miniHeight; i++) {
-      const value = miniMap[i]
-      if (value > 0) {
-        const miniX = i % miniWidth;
-        const miniY = i / miniWidth | 0;
-        const x0 = miniX * MINIMAP_SCALE
-        const x1 = Math.min(x0 + MINIMAP_SCALE, width);
-        const y0 = miniY * MINIMAP_SCALE
-        const y1 = Math.min(y0 + MINIMAP_SCALE, height);
-        d32i = x0 + y0 * d32iWidth + d32iPadding;
-        const d32iYinc = d32iWidth - x1 + x0;
-        for (let y = y0; y < y1; y++) {
-          for (let x = x0; x < x1; x++) {
-            diff32[d32i++] |= COLOR32_MINIMAP;
+            sum1 += bY;
+            sum2 += cY;
+            sum1Sq += bY * bY;
+            sum2Sq += cY * cY;
+            sum12 += bY * cY;
           }
-          d32i += d32iYinc;
+          const mu1 = sum1 / 256;
+          const mu2 = sum2 / 256;
+          const mu1Sq = mu1 * mu1;
+          const mu2Sq = mu2 * mu2;
+          const mu12 = mu1 * mu2;
+          const sigma1Sq = (sum1Sq - 256 * mu1Sq) / 255;
+          const sigma2Sq = (sum2Sq - 256 * mu2Sq) / 255;
+          const sigma12 = (sum12 - 256 * mu12) / 255;
+          // Compute SSIM
+          const numerator = (2 * mu12 + C1) * (2 * sigma12 + C2);
+          const denominator = (mu1Sq + mu2Sq + C1) * (sigma1Sq + sigma2Sq + C2);
+          ssim = numerator / denominator;
+          // track the lowest ssim score = lowest (local) similarity
+          if (ssim < lowestSsim) {
+            lowestSsim = ssim;
+          }
+        }
+
+        // TODO update diff image
+
+      }
+    }
+
+
+
+  } else {
+    // Diff every pixel
+    b8i = 0;
+    const miniHeight = Math.ceil(height / MINIMAP_SCALE);
+    const miniWidth = Math.ceil(width / MINIMAP_SCALE);
+    const miniMap = new Uint8ClampedArray(miniWidth * miniHeight);
+    const d32iPadding = diffType === SideBySide ? width : 0;
+    const d32iWidth = d32iPadding * 2 + width;
+    const maxDimension = Math.max(width, height);
+    const maxMiniDimension = Math.max(miniWidth, miniHeight);
+    const axisMiniIndex = new Uint32Array(maxDimension);
+
+    let miniIndex = 0;
+    for (let i = 0; i < maxMiniDimension; i++) {
+      axisMiniIndex.fill(i, miniIndex, Math.min(miniIndex + MINIMAP_SCALE, maxDimension));
+      miniIndex += MINIMAP_SCALE;
+    }
+
+    for (let y = 0; y < height; y++) {
+      const miniIndexY = axisMiniIndex[y] * miniWidth;
+      // For side-by-side diff, copy the baseline and candidate on the sides
+      if (d32iPadding > 0) {
+        diff32.set(new Uint32Array(bBuffer, b8i, width), d32i);
+        d32i += width;
+        diff32.set(new Uint32Array(cBuffer, b8i, width), d32i + width);
+      }
+
+      let hashIndex = (y ^ HASH_SPREAD) * HASH_SPREAD;
+      for (let x = 0; x < width; x++, d32i++, b32i++, b8i += 4, hashIndex++) {
+        // Quick check against the Uint32
+        if (baseline32[b32i] === candidate32[b32i]) {
+          continue;
+        }
+
+        // Get the r,g,b -> y,i,q => YIQ square delta
+        const dr = candidate8[b8i] - baseline8[b8i];
+        const dg = candidate8[b8i + 1] - baseline8[b8i + 1];
+        const db = candidate8[b8i + 2] - baseline8[b8i + 2];
+
+        const dy = dr * 0.29889531 + dg * 0.58662247 + db * 0.11448223;
+        const di = dr * 0.59597799 - dg * 0.27417610 - db * 0.32180189;
+        const dq = dr * 0.21147017 - dg * 0.52261711 + db * 0.31114694;
+
+        const delta = dy * dy * 0.5053 + di * di * 0.299 + dq * dq * 0.1957;
+        if (delta > deltaThreshold) {
+          const miniIndex = miniIndexY + axisMiniIndex[x];
+          miniMap[miniIndex]++;
+          diffCount++;
+          const dyAbs = Math.abs(dy);
+          cumulatedDiff += dyAbs;
+          diff32[d32i] =
+            (dy > 0 ? color32Added : color32Removed) +
+            (Math.min(192, dyAbs * 8) << 24);
+
+          if (hash === 0) {
+            hashStart = hashIndex;
+          }
+          hash += hashIndex;
+        }
+      }
+      d32i += d32iPadding;
+    }
+    hash -= hashStart;
+    cumulatedDiff /= 256;
+
+    // Apply minimap overlay
+    if (enableMinimap) {
+      for (let i = 0; i < miniWidth * miniHeight; i++) {
+        const value = miniMap[i]
+        if (value > 0) {
+          const miniX = i % miniWidth;
+          const miniY = i / miniWidth | 0;
+          const x0 = miniX * MINIMAP_SCALE
+          const x1 = Math.min(x0 + MINIMAP_SCALE, width);
+          const y0 = miniY * MINIMAP_SCALE
+          const y1 = Math.min(y0 + MINIMAP_SCALE, height);
+          d32i = x0 + y0 * d32iWidth + d32iPadding;
+          const d32iYinc = d32iWidth - x1 + x0;
+          for (let y = y0; y < y1; y++) {
+            for (let x = x0; x < x1; x++) {
+              diff32[d32i++] |= COLOR32_MINIMAP;
+            }
+            d32i += d32iYinc;
+          }
         }
       }
     }
-  }
 
-  if (cumulatedDiff > options.cumulatedThreshold) {
-    return { diff: diffCount, cumulatedDiff, hash };
+    if (cumulatedDiff > cumulatedThreshold) {
+      return { diff: diffCount, cumulatedDiff, hash };
+    }
   }
 
   return { diff: 0, cumulatedDiff: 0, hash: 0 };
@@ -176,7 +260,12 @@ export const diff = (
   diff8: Uint8Array | Uint8ClampedArray,
   width: number,
   height: number,
-  options: Options
+  options: Options = {
+    threshold: 0.03,
+    cumulatedThreshold: 0.5,
+    enableMinimap: false,
+    mode: "basic"
+  }
 ): Result => diffImageDatas({ width, height, data: baseline8 } as ImageData,
   { width, height, data: candidate8 } as ImageData,
   { width: width * diff8.length / baseline8.length, height, data: diff8 } as ImageData, options);

--- a/src/index.ts
+++ b/src/index.ts
@@ -93,26 +93,33 @@ export const diffImageDatas = (
 
   if (mode === "ssim") {
     // SSIM diff by 16x16 patch
-    const ssimThreshold = 1 - threshold ** .5;
+    //const ssimThreshold = 1 - threshold;// ** .5;
+    console.log(`${width} x ${height}`);
 
     // Prepare the diff buffer
     if (diffType === SideBySide) {
       for (let y = 0; y < height; y++) {
         const index32 = y * width;
         const diffIndex32 = index32 * 3;
-        diff32.set(new Uint32Array(baseline32, index32, width), diffIndex32);
-        diff32.set(new Uint32Array(candidate32, index32, width), diffIndex32 + width + width);
+        const baseline32Span = baseline32.slice(index32, index32 + width);
+        diff32.set(baseline32Span, diffIndex32);
+        const candidate32Span = candidate32.slice(index32, index32 + width);
+        diff32.set(candidate32Span, diffIndex32 + width + width);
       }
     }
 
     // prepare patch offsets to walk within the patches
+    const patchOffsets8 = [];
     const patchOffsets32 = [];
+    const patchOffsetsDiff32 = [];
     for (let y = 0; y < 16; y++) {
       for (let x = 0; x < 16; x++) {
+        patchOffsetsDiff32.push(x + y * d32iWidth)
         patchOffsets32.push(x + y * width);
+        patchOffsets8.push((x + y * width) * 4);
       }
     }
-    const patchOffsets8 = patchOffsets32.map(v => v * 4);
+    // const patchOffsets8 = patchOffsets32.map(v => v * 4);
 
     // SSIM constants
     const K1 = 0.01;
@@ -126,14 +133,13 @@ export const diffImageDatas = (
       for (let x = 0; x < width; x += 16) {
         const index32 = x + y * width;
 
-        let ssim = 1;
         // Quick check using RGBA32 values
         let breakAndComputeSsim = false;
         for (let i = 0; i < 256 && !breakAndComputeSsim; i++) {
           const indexPlusOffset32 = index32 + patchOffsets32[i];
           breakAndComputeSsim = baseline32[indexPlusOffset32] !== candidate32[indexPlusOffset32];
         }
-        if (breakAndComputeSsim) {
+        if (breakAndComputeSsim || true) {
           // walk patch on 8bits valuse to compute the Y, and SSIM
           // Single pass computation
           const index8 = index32 * 4;
@@ -141,8 +147,8 @@ export const diffImageDatas = (
           const patchDiff = [];
           for (let i = 0; i < 256; i++) {
             const indexPlusOffset8 = index8 + patchOffsets8[i];
-            const bY = baseline8[indexPlusOffset8] * 0.29889531 + baseline8[indexPlusOffset8 + 1] * 0.58662247 + baseline8[indexPlusOffset8 + 2] * 0.11448223;;
-            const cY = candidate8[indexPlusOffset8] * 0.29889531 + candidate8[indexPlusOffset8 + 1] * 0.58662247 + candidate8[indexPlusOffset8 + 2] * 0.11448223;;
+            const bY = baseline8[indexPlusOffset8] * 0.299 + baseline8[indexPlusOffset8 + 1] * 0.587 + baseline8[indexPlusOffset8 + 2] * 0.114;
+            const cY = candidate8[indexPlusOffset8] * 0.299 + candidate8[indexPlusOffset8 + 1] * 0.587 + candidate8[indexPlusOffset8 + 2] * 0.114;
             patchDiff.push(cY - bY);
 
             sum1 += bY;
@@ -162,9 +168,9 @@ export const diffImageDatas = (
           // Compute SSIM
           const numerator = (2 * mu12 + C1) * (2 * sigma12 + C2);
           const denominator = (mu1Sq + mu2Sq + C1) * (sigma1Sq + sigma2Sq + C2);
-          ssim = numerator / denominator;
+          const ssim = numerator / denominator;
           // track the lowest ssim score = lowest (local) similarity
-          if (ssim < ssimThreshold) {
+          if (ssim < 1) {
             // Update the diff32 buffer with red/green diff + minimap
             const diffIndex32 = x + y * d32iWidth + d32iPadding;
             for (let i = 0; i < 256; i++) {
@@ -173,9 +179,9 @@ export const diffImageDatas = (
               if (dyAbs > threshold) {
                 diffCount++;
               }
-              diff32[diffIndex32 + patchOffsets32[i]] = (
+              diff32[diffIndex32 + patchOffsetsDiff32[i]] = (
                   (dy > 0 ? color32Added : color32Removed)
-                  + (Math.min(192, dyAbs * 8) << 24)
+                  + (Math.min(192, dyAbs * 2) << 24)
                 ) | color32Minimap;
             }
           }
@@ -185,10 +191,11 @@ export const diffImageDatas = (
         }
       }
     }
-
+    console.log(`lowestSsim = ${lowestSsim}`);
     if (lowestSsim < 1) {
       return {diff: diffCount, cumulatedDiff: 1 - lowestSsim, hash: 0};
     }
+      return {diff: 1337, cumulatedDiff: .42, hash: 0};
   } else {
     // Diff every pixel
     b8i = 0;

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,9 +86,24 @@ export const diffImageDatas = (
   const isDarkTheme = averageBrightness < 128;
   const color32Added = isDarkTheme ? COLOR32_ADDED : COLOR32_REMOVED;
   const color32Removed = isDarkTheme ? COLOR32_REMOVED : COLOR32_ADDED;
+  const color32Minimap = enableMinimap ? COLOR32_MINIMAP : 0;
+
+  const d32iPadding = diffType === SideBySide ? width : 0;
+  const d32iWidth = d32iPadding * 2 + width;
 
   if (mode === "ssim") {
     // SSIM diff by 16x16 patch
+    const ssimThreshold = 1 - threshold ** .5;
+
+    // Prepare the diff buffer
+    if (diffType === SideBySide) {
+      for (let y = 0; y < height; y++) {
+        const index32 = y * width;
+        const diffIndex32 = index32 * 3;
+        diff32.set(new Uint32Array(baseline32, index32, width), diffIndex32);
+        diff32.set(new Uint32Array(candidate32, index32, width), diffIndex32 + width + width);
+      }
+    }
 
     // prepare patch offsets to walk within the patches
     const patchOffsets32 = [];
@@ -106,6 +121,7 @@ export const diffImageDatas = (
     const C2 = (K2 * 255) ** 2;
     // Walk each patch, track the lowest SSIM aka lowest similarity
     let lowestSsim = 1;
+    let diffCount = 0;
     for (let y = 0; y < height; y += 16) {
       for (let x = 0; x < width; x += 16) {
         const index32 = x + y * width;
@@ -122,10 +138,12 @@ export const diffImageDatas = (
           // Single pass computation
           const index8 = index32 * 4;
           let sum1 = 0, sum2 = 0, sum1Sq = 0, sum2Sq = 0, sum12 = 0;
+          const patchDiff = [];
           for (let i = 0; i < 256; i++) {
             const indexPlusOffset8 = index8 + patchOffsets8[i];
             const bY = baseline8[indexPlusOffset8] * 0.29889531 + baseline8[indexPlusOffset8 + 1] * 0.58662247 + baseline8[indexPlusOffset8 + 2] * 0.11448223;;
             const cY = candidate8[indexPlusOffset8] * 0.29889531 + candidate8[indexPlusOffset8 + 1] * 0.58662247 + candidate8[indexPlusOffset8 + 2] * 0.11448223;;
+            patchDiff.push(cY - bY);
 
             sum1 += bY;
             sum2 += cY;
@@ -146,26 +164,37 @@ export const diffImageDatas = (
           const denominator = (mu1Sq + mu2Sq + C1) * (sigma1Sq + sigma2Sq + C2);
           ssim = numerator / denominator;
           // track the lowest ssim score = lowest (local) similarity
+          if (ssim < ssimThreshold) {
+            // Update the diff32 buffer with red/green diff + minimap
+            const diffIndex32 = x + y * d32iWidth + d32iPadding;
+            for (let i = 0; i < 256; i++) {
+              const dy = patchDiff[i];
+              const dyAbs = Math.abs(dy);
+              if (dyAbs > threshold) {
+                diffCount++;
+              }
+              diff32[diffIndex32 + patchOffsets32[i]] = (
+                  (dy > 0 ? color32Added : color32Removed)
+                  + (Math.min(192, dyAbs * 8) << 24)
+                ) | color32Minimap;
+            }
+          }
           if (ssim < lowestSsim) {
             lowestSsim = ssim;
           }
         }
-
-        // TODO update diff image
-
       }
     }
 
-
-
+    if (lowestSsim < 1) {
+      return {diff: diffCount, cumulatedDiff: 1 - lowestSsim, hash: 0};
+    }
   } else {
     // Diff every pixel
     b8i = 0;
     const miniHeight = Math.ceil(height / MINIMAP_SCALE);
     const miniWidth = Math.ceil(width / MINIMAP_SCALE);
     const miniMap = new Uint8ClampedArray(miniWidth * miniHeight);
-    const d32iPadding = diffType === SideBySide ? width : 0;
-    const d32iWidth = d32iPadding * 2 + width;
     const maxDimension = Math.max(width, height);
     const maxMiniDimension = Math.max(miniWidth, miniHeight);
     const axisMiniIndex = new Uint32Array(maxDimension);

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,10 +20,6 @@ export const diffImageDatas = (
   const cumulatedThreshold = options.cumulatedThreshold ?? 0.5;
   const enableMinimap = options.enableMinimap ?? false;
   const mode = options.mode ?? "basic";
-  // if (options.threshold === undefined) { options.threshold = 0.03; }
-  // if (options.cumulatedThreshold === undefined) { options.cumulatedThreshold = .5; }
-  // if (options.enableMinimap === undefined) { options.enableMinimap = false; }
-  // if (options.mode === undefined) { options.mode = "basic"; }
 
   const { width, height } = baseline;
   const area = width * height;
@@ -92,18 +88,19 @@ export const diffImageDatas = (
   const d32iWidth = d32iPadding * 2 + width;
 
   if (mode === "ssim") {
-    // SSIM diff by 16x16 patch
-    //const ssimThreshold = 1 - threshold;// ** .5;
-    console.log(`${width} x ${height}`);
+    // SSIM diff by NxN patch
+    const ssimPad = 64;
+    const ssimPad2 = ssimPad * ssimPad;
+    const ssimPad2_1 = ssimPad2 - 1;
 
     // Prepare the diff buffer
     if (diffType === SideBySide) {
       for (let y = 0; y < height; y++) {
         const index32 = y * width;
         const diffIndex32 = index32 * 3;
-        const baseline32Span = baseline32.slice(index32, index32 + width);
+        const baseline32Span = new Uint32Array(baseline32.buffer, y * width * 4, width);
         diff32.set(baseline32Span, diffIndex32);
-        const candidate32Span = candidate32.slice(index32, index32 + width);
+        const candidate32Span = new Uint32Array(candidate32.buffer, y * width * 4, width);
         diff32.set(candidate32Span, diffIndex32 + width + width);
       }
     }
@@ -112,8 +109,9 @@ export const diffImageDatas = (
     const patchOffsets8 = [];
     const patchOffsets32 = [];
     const patchOffsetsDiff32 = [];
-    for (let y = 0; y < 16; y++) {
-      for (let x = 0; x < 16; x++) {
+    const patchDiff = [];;
+    for (let y = 0; y < ssimPad; y++) {
+      for (let x = 0; x < ssimPad; x++) {
         patchOffsetsDiff32.push(x + y * d32iWidth)
         patchOffsets32.push(x + y * width);
         patchOffsets8.push((x + y * width) * 4);
@@ -129,75 +127,79 @@ export const diffImageDatas = (
     // Walk each patch, track the lowest SSIM aka lowest similarity
     let lowestSsim = 1;
     let diffCount = 0;
-    for (let y = 0; y < height; y += 16) {
-      for (let x = 0; x < width; x += 16) {
+    const threshold255 = threshold * 255;
+    for (let y = 0; y < height; y += ssimPad) {
+      for (let x = 0; x < width; x += ssimPad) {
         const index32 = x + y * width;
 
         // Quick check using RGBA32 values
         let breakAndComputeSsim = false;
-        for (let i = 0; i < 256 && !breakAndComputeSsim; i++) {
+        for (let i = 0; i < ssimPad2 && !breakAndComputeSsim; i++) {
           const indexPlusOffset32 = index32 + patchOffsets32[i];
-          breakAndComputeSsim = baseline32[indexPlusOffset32] !== candidate32[indexPlusOffset32];
+          breakAndComputeSsim = baseline32[indexPlusOffset32] != candidate32[indexPlusOffset32];
         }
-        if (breakAndComputeSsim || true) {
+        if (breakAndComputeSsim) {
           // walk patch on 8bits valuse to compute the Y, and SSIM
           // Single pass computation
           const index8 = index32 * 4;
-          let sum1 = 0, sum2 = 0, sum1Sq = 0, sum2Sq = 0, sum12 = 0;
-          const patchDiff = [];
-          for (let i = 0; i < 256; i++) {
+          let sumB = 0, sumC = 0, sumBB = 0, sumCC = 0, sumBC = 0;
+          for (let i = 0; i < ssimPad2; i++) {
             const indexPlusOffset8 = index8 + patchOffsets8[i];
-            const bY = baseline8[indexPlusOffset8] * 0.299 + baseline8[indexPlusOffset8 + 1] * 0.587 + baseline8[indexPlusOffset8 + 2] * 0.114;
-            const cY = candidate8[indexPlusOffset8] * 0.299 + candidate8[indexPlusOffset8 + 1] * 0.587 + candidate8[indexPlusOffset8 + 2] * 0.114;
-            patchDiff.push(cY - bY);
-
-            sum1 += bY;
-            sum2 += cY;
-            sum1Sq += bY * bY;
-            sum2Sq += cY * cY;
-            sum12 += bY * cY;
+            const b = baseline8[indexPlusOffset8] * 0.299 + baseline8[indexPlusOffset8 + 1] * 0.587 + baseline8[indexPlusOffset8 + 2] * 0.114;
+            const c = candidate8[indexPlusOffset8] * 0.299 + candidate8[indexPlusOffset8 + 1] * 0.587 + candidate8[indexPlusOffset8 + 2] * 0.114;
+            patchDiff[i] = c - b;
+            sumB += b;
+            sumC += c;
+            sumBB += b * b;
+            sumCC += c * c;
+            sumBC += b * c;
           }
-          const mu1 = sum1 / 256;
-          const mu2 = sum2 / 256;
-          const mu1Sq = mu1 * mu1;
-          const mu2Sq = mu2 * mu2;
-          const mu12 = mu1 * mu2;
-          const sigma1Sq = (sum1Sq - 256 * mu1Sq) / 255;
-          const sigma2Sq = (sum2Sq - 256 * mu2Sq) / 255;
-          const sigma12 = (sum12 - 256 * mu12) / 255;
+          // Compute means
+          const meanB = sumB / ssimPad2;
+          const meanC = sumC / ssimPad2;
+          // Compute variances and covariance
+          const varB = (sumBB - ssimPad2 * meanB * meanB) / ssimPad2_1;
+          const varC = (sumCC - ssimPad2 * meanC * meanC) / ssimPad2_1;
+          const covBC = (sumBC - ssimPad2 * meanB * meanC) / ssimPad2_1;
           // Compute SSIM
-          const numerator = (2 * mu12 + C1) * (2 * sigma12 + C2);
-          const denominator = (mu1Sq + mu2Sq + C1) * (sigma1Sq + sigma2Sq + C2);
+          const numerator = (2 * meanB * meanC + C1) * (2 * covBC + C2);
+          const denominator = (meanB * meanB + meanC * meanC + C1) * (varB + varC + C2);
           const ssim = numerator / denominator;
           // track the lowest ssim score = lowest (local) similarity
-          if (ssim < 1) {
+          if (ssim < 1 - threshold) {
             // Update the diff32 buffer with red/green diff + minimap
             const diffIndex32 = x + y * d32iWidth + d32iPadding;
-            for (let i = 0; i < 256; i++) {
+            diffCount++;
+            for (let i = 0; i < ssimPad2; i++) {
               const dy = patchDiff[i];
               const dyAbs = Math.abs(dy);
-              if (dyAbs > threshold) {
+              if (dyAbs > threshold255) {
                 diffCount++;
-              }
-              diff32[diffIndex32 + patchOffsetsDiff32[i]] = (
-                  (dy > 0 ? color32Added : color32Removed)
-                  + (Math.min(192, dyAbs * 2) << 24)
+                diff32[diffIndex32 + patchOffsetsDiff32[i]] = (
+                  (dy > 0 ? color32Added : color32Removed) +
+                  (Math.min(192, dyAbs * 2) << 24)
                 ) | color32Minimap;
+                const hashIndex = (y ^ HASH_SPREAD) * HASH_SPREAD + (x ^ HASH_SPREAD) + i;
+                if (hash === 0) {
+                  hashStart = hashIndex;
+                }
+                hash += hashIndex;
+              } else {
+                diff32[diffIndex32 + patchOffsetsDiff32[i]] = color32Minimap;
+              }
             }
-          }
-          if (ssim < lowestSsim) {
-            lowestSsim = ssim;
+            if (ssim < lowestSsim) {
+              lowestSsim = ssim;
+            }
           }
         }
       }
     }
-    console.log(`lowestSsim = ${lowestSsim}`);
     if (lowestSsim < 1) {
-      return {diff: diffCount, cumulatedDiff: 1 - lowestSsim, hash: 0};
+      hash -= hashStart;
+      return { diff: diffCount, cumulatedDiff: lowestSsim, hash };
     }
-      return {diff: 1337, cumulatedDiff: .42, hash: 0};
-  } else {
-    // Diff every pixel
+  } else { // Diff every pixel
     b8i = 0;
     const miniHeight = Math.ceil(height / MINIMAP_SCALE);
     const miniWidth = Math.ceil(width / MINIMAP_SCALE);


### PR DESCRIPTION
Add SSIM image diffing mode to make Pixel Buffer Diff resiliant to small local and global AA differences. 
Use 64x64 SSIM patches, with early check using the 32bits RGBA values, and return the lowest SSIM value as we care about the biggest differences.

Validated the changes against the basic YIQ  approach and a corpus of 13,096 x2 screenshots (including 1497 known flaky screenshots) for an internal repository from a repo-wide change that should be no-op, but bumped the browsers.

Here are the results, single threaded
method | diffs found | duration
-|-|-
Reliability pipelines| 1497|n/a
YIQ | 11,702 | 1596 seconds
SSIM | 794 | 699seconds

**~15x less false positives, well under the max number of known flaky screenshots that should be our ceiling for a no-op change, and 2x as fast.**


https://en.wikipedia.org/wiki/Structural_similarity_index_measure
https://medium.com/@tsdhrm/ssim-measuring-what-we-actually-see-5350c4a0c025